### PR TITLE
Fixed Bug in Which Mapper Can't Map to ListConfig if Input is None

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,19 +3,25 @@
 History
 -------
 
+0.3.5 (2018-06-14)
+~~~~~~~~~~~~~~~~~~~~~
+
+* Fixed bug in which TypeError would result if a None value were mapped to a ``ListConfig``
+
+
 0.3.4 (2017-07-28)
 ~~~~~~~~~~~~~~~~~~~~~
 
-* Using wheel for distribution.
-* Removed tests from being packaged.
-* Switched to using Python 3.6 vs 3.5 for running Travis builds.
+* Using wheel for distribution
+* Removed tests from being packaged
+* Switched to using Python 3.6 vs 3.5 for running Travis builds
 
 0.3.3 (2016-05-15)
 ~~~~~~~~~~~~~~~~~~~~~
 
 * Fixed bug where global LUT would leak data when calling expressions
   within custom lookups. See `#11 <https://github.com/dealertrack/simplepath/issues/11>`_.
-* Switched to using Python 3.5 vs 3.4 for running Travis builds.
+* Switched to using Python 3.5 vs 3.4 for running Travis builds
 
 0.3.2 (2015-09-14)
 ~~~~~~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 0.3.5 (2018-06-14)
 ~~~~~~~~~~~~~~~~~~~~~
 
-* Fixed bug in which TypeError would result if a None value were mapped to a ``ListConfig``
+* Fixed bug in which ``TypeError`` would result if a ``None`` value were mapped to a ``ListConfig``
 
 
 0.3.4 (2017-07-28)

--- a/simplepath/__init__.py
+++ b/simplepath/__init__.py
@@ -3,4 +3,4 @@ from __future__ import unicode_literals
 
 
 __author__ = 'Miroslav Shubernetskiy'
-__version__ = '0.3.4'
+__version__ = '0.3.5'

--- a/simplepath/mapper.py
+++ b/simplepath/mapper.py
@@ -285,9 +285,10 @@ class MapperBase(object):
             context=self.get_lookup_context(),
         )
 
-        for value in input_list:
-            # due to relative lookups, cannot use main lut
-            output.append(self.map_config_node(node, value, super_root, {}))
+        if input_list is not None:
+            for value in input_list:
+                # due to relative lookups, cannot use main lut
+                output.append(self.map_config_node(node, value, super_root, {}))
 
         return output
 
@@ -323,7 +324,7 @@ class MapperBase(object):
 
         else:
             raise TypeError(
-                '"{}" does not quality for free ice-cream.'
+                '"{}" does not qualify for free ice-cream.'
                 ''.format(type(node))
             )
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -490,6 +490,21 @@ class TestMapperBase(unittest.TestCase):
             {},
         )
 
+    @mock.patch.object(MapperBase, 'get_lookup_context')
+    def test_map_list_node_none_input_list(self, mock_get_lookup_context):
+        node = mock.MagicMock(
+            root=mock.MagicMock(return_value=None)
+        )
+
+        actual = self.mapper.map_list_node(
+            node,
+            mock.sentinel.data,
+            mock.sentinel.root,
+            mock.sentinel.lut,
+        )
+
+        self.assertListEqual([], actual)
+
     @mock.patch.object(MapperBase, 'map_node')
     def test_map_list(self, mock_map_node):
         nodes = [mock.MagicMock(spec=Expression)]

--- a/tests/test_z_integration.py
+++ b/tests/test_z_integration.py
@@ -24,6 +24,12 @@ class TestIntegration(unittest.TestCase):
                     Value('with'),
                     Value('Ion Engine'),
                 ],
+                'munchies': ListConfig(
+                    'example.food',
+                    {
+                        'item': 'name',
+                    }
+                ),
             }
 
         data = {
@@ -42,7 +48,8 @@ class TestIntegration(unittest.TestCase):
                         'planet': 'Space',
                         'residents': 'aliens',
                     },
-                ]
+                ],
+                'food': None,
             },
             'cool_object': 'Space Shuttle',
         }
@@ -68,7 +75,8 @@ class TestIntegration(unittest.TestCase):
                 'Space Shuttle',
                 'with',
                 'Ion Engine',
-            ]
+            ],
+            'munchies': []
         }
 
         self.assertDictEqual(Config.map_data(data), expected)


### PR DESCRIPTION
Example:
if value of config is the following
```python
ListConfig('example.food', {'item': 'name'})
```
And input is
```python
{'example': {'food': None}}
```

The following error is shown
`TypeError: 'NoneType' object is not iterable`

This fix just returns an empty list if the input is `None`.